### PR TITLE
Add support for SystemVerilog, and allow passing additional arguments to verilator

### DIFF
--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -406,8 +406,8 @@ class PyVerilator:
         # get the module name from the verilog file name
         top_verilog_file_base = os.path.basename(top_verilog_file)
         verilog_module_name, extension = os.path.splitext(top_verilog_file_base)
-        if extension != '.v':
-            raise ValueError('PyVerilator() expects top_verilog_file to be a verilog file ending in .v')
+        if extension not in ['.v', '.sv']:
+            raise ValueError('PyVerilator() expects top_verilog_file to be a verilog file ending in .v or .sv')
 
         # prepare the path for the C++ wrapper file
         if not os.path.exists(build_dir):

--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -433,7 +433,7 @@ class PyVerilator:
             if isinstance(value, str):
                 value = "\"{}\"".format(value)
 
-        param_args.append("-G{}={}".format(param, value))
+            param_args.append("-G{}={}".format(param, value))
 
         # Verilator is a perl program that is run as an executable
         # Old versions of Verilator are interpreted as a perl script by the shell,

--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -372,7 +372,7 @@ class PyVerilator:
     def build(cls, top_verilog_file, verilog_path = [], build_dir = 'obj_dir',
               json_data = None, gen_only = False, quiet=False,
               command_args=(), verilog_defines=(),
-              params={}, verilator_args=(), extra_cflags=""):
+              params={}, verilator_args=(), extra_cflags="", verilog_module_name=None):
         """Build an object file from verilog and load it into python.
 
         Creates a folder build_dir in which it puts all the files necessary to create
@@ -412,7 +412,12 @@ class PyVerilator:
 
         # get the module name from the verilog file name
         top_verilog_file_base = os.path.basename(top_verilog_file)
-        verilog_module_name, extension = os.path.splitext(top_verilog_file_base)
+
+        if verilog_module_name is None:
+            verilog_module_name, extension = os.path.splitext(top_verilog_file_base)
+        else:
+            _, extension = os.path.splitext(top_verilog_file_base)
+
         if extension not in ['.v', '.sv']:
             raise ValueError('PyVerilator() expects top_verilog_file to be a verilog file ending in .v or .sv')
 


### PR DESCRIPTION
Recently discovered this library and started integrating into my workflow and I've absolutely loved it, but noticed a few features that were lacking and added them in:

1. SystemVerilog support - The `build` function was hardcoded to only allow ".v" files, added ".sv" as well to allow for top-level files to be SystemVerilog (of which a sufficient subset is supported in Verilator that using SystemVerilog files with Verilator is not uncommon).

2. Allow parameter overrides - Some of my tests passed parameters into the top-level module to allow testing the module under different conditions, so `build` now takes a parameters dict object that is converted into `-G` flags and passed to verilator.

3. Allow passing additional custom arguments to verilator at build time.