### PR TITLE
Remove depreciated call to Verilated::flushCall()

### DIFF
--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -455,13 +455,13 @@ class PyVerilator:
                             result.group(4)) == 0:
                         # this is an internal signal
                         signal_width = int(result.group(3)) - int(result.group(4)) + 1
-                        return (signal_name, signal_width)
+                        return (signal_name.strip('&'), signal_width)
                     else:
                         return None
                 else:
                     # this is an input or an output
                     signal_width = int(result.group(3)) - int(result.group(4)) + 1
-                    return (signal_name, signal_width)
+                    return (signal_name.strip('&'), signal_width)
             else:
                 return None
 

--- a/pyverilator/verilatorcpp.py
+++ b/pyverilator/verilatorcpp.py
@@ -72,7 +72,7 @@ void vl_finish (const char* filename, int linenum, const char* hier) VL_MT_UNSAF
         VL_PRINTF("- %s:%d: Verilog $finish\\n", filename, linenum);  // Not VL_PRINTF_MT, already on main thread
         if (Verilated::gotFinish()) {{
             VL_PRINTF("- %s:%d: Second verilog $finish, exiting\\n", filename, linenum);  // Not VL_PRINTF_MT, already on main thread
-            Verilated::flushCall();
+            Verilated::runFlushCallbacks();
             exit(0);
         }}
         Verilated::gotFinish(true);


### PR DESCRIPTION
* flushCall is depreciated and replaced with runFlushCallbacks