### PR TITLE
Hot fix limit number of jobs

### DIFF
--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -7,6 +7,7 @@ import re
 import warnings
 import sys
 import typing
+import multiprocessing
 from keyword import iskeyword
 import pyverilator.verilatorcpp as template_cpp
 import tclwrapper
@@ -493,7 +494,7 @@ class PyVerilator:
 
         # call make to build the pyverilator shared object
         make_args = ['make', '-C', build_dir, '-f', 'V%s.mk' % verilog_module_name,
-                     'LDFLAGS=-fPIC -shared', '--jobs']
+                     'LDFLAGS=-fPIC -shared', '--jobs', str(multiprocessing.cpu_count())]
         call_process(make_args, quiet=quiet, output_stream=output_stream)
         so_file = os.path.join(build_dir, 'V' + verilog_module_name)
         return cls(so_file, command_args=command_args)

--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -434,6 +434,7 @@ class PyVerilator:
                            '-fPIC -shared --std=c++11 -DVL_USER_FINISH',
                             '--trace',
                             '--cc',
+                            '--coverage',
                             top_verilog_file,
                             '--exe',
                             verilator_cpp_wrapper_path]

--- a/pyverilator/pyverilator.py
+++ b/pyverilator/pyverilator.py
@@ -490,7 +490,7 @@ class PyVerilator:
 
         # call make to build the pyverilator shared object
         make_args = ['make', '-C', build_dir, '-f', 'V%s.mk' % verilog_module_name,
-                     'LDFLAGS=-fPIC -shared']
+                     'LDFLAGS=-fPIC -shared', '--jobs']
         call_process(make_args, quiet=quiet)
         so_file = os.path.join(build_dir, 'V' + verilog_module_name)
         return cls(so_file, command_args=command_args)

--- a/pyverilator/verilatorcpp.py
+++ b/pyverilator/verilatorcpp.py
@@ -120,6 +120,7 @@ bool get_finished() {{
     return Verilated::gotFinish();
 }}
 void set_finished(bool b) {{
+    Verilated::threadContextp()->coveragep()->write("coverage.dat");
     Verilated::gotFinish(b);
 }}
 void set_vl_finish_callback(vl_finish_callback callback) {{


### PR DESCRIPTION
PyVerilator was running too many jobs and hogging the server's CPUs for long builds. This change makes it so it can't create more jobs that CPUs available.